### PR TITLE
Add Gooee dev account and qa tables

### DIFF
--- a/src/dev-config.hjson
+++ b/src/dev-config.hjson
@@ -1,0 +1,29 @@
+{
+	// target region - for example 'us-east-1' or 'eu-west-1'
+	"region" : "us-east-1",
+
+	// firehose destination information
+	"firehoseDeliveryBucket" : "device-oracle",
+	"firehoseDeliveryPrefix" : "dynamodb/backup",
+
+	// the ARN of the IAM role that Kinesis Firehose will use to write to S3
+	"firehoseDeliveryRoleArn" : "arn:aws:iam::936783871914:role/dynamodb_backup_firehose_delivery_role",
+
+	// size in MB of dynamo DB backup files to write to S3
+	"firehoseDeliverySizeMB" : 128,
+
+	// output interval in seconds for backup files
+	"firehoseDeliveryIntervalSeconds" : 60,
+
+	// IAM Role ARN for which AWS Lambda uses to write to Kinesis Firehose
+	"lambdaExecRoleArn" : "arn:aws:iam::936783871914:role/DynamoDB-Backup-LambdaExecRole",
+
+	// IAM Role used by CloudWatch Events to read from AWS CloudTrail and call AWS Lambda
+	"cloudWatchRoleArn" : "arn:aws:iam::936783871914:role/DynamoDB-Backup-CloudWatchEventsRole",
+
+	// number of update records to stream to the continuous backup function at one time. This number times your DDB record size must be < 128K
+	"streamsMaxRecordsBatch" : 1000,
+
+	// regular expression to run against incoming CreateTable events, to implement filtering of which tables are configured
+	"tableNameMatchRegex": ".*"
+}

--- a/src/dev_whitelist.hjson
+++ b/src/dev_whitelist.hjson
@@ -1,0 +1,8 @@
+{
+  "provisionAll": false,
+  "tableNames": [
+    "qa-device-oracle-DeviceOracleProdDB-1TNZMUI2Z603D",
+    "qa-device-oracle-DeviceOracleQaDB-1G0N8320O31MO",
+    "qa-device-oracle-DeviceOracleStageDB-1TZW6YQZV6YBI"
+  ]
+}

--- a/src/iam_roles_formation.yml
+++ b/src/iam_roles_formation.yml
@@ -1,0 +1,128 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: IAM roles needed to ensure DynamoDB backups
+
+Resources:
+
+  FirehoseDeliveryRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: dynamodb_backup_firehose_delivery_role
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - firehose.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+
+  FirehoseDeliveryRolePolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyName: dynamodb_backup_firehose_delivery_policy
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action:
+              - 's3:GetBucketLocation'
+              - 's3:ListBucket'
+              - 's3:ListBucketMultipartUploads'
+              - 's3:AbortMultipartUpload'
+              - 's3:PutObject'
+              - 's3:GetObject'
+            Resource:
+              - 'arn:aws:s3:::device-oracle'
+              - 'arn:aws:s3:::device-oracle/*'
+      Roles:
+        - !Ref FirehoseDeliveryRole
+
+  DynamoDBBackupLambdaExecRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: DynamoDB-Backup-LambdaExecRole
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+
+  DynamoDBBackupLambdaExecRolePolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyName: DynamoDB-Backup-LambdaExecPolicy
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: 'cloudwatch:*'
+            Resource: '*'
+          - Effect: Allow
+            Action:
+              - 'firehose:CreateDeliveryStream'
+              - 'firehose:DescribeDeliveryStream'
+              - 'firehose:ListDeliveryStreams'
+              - 'firehose:PutRecord'
+              - 'firehose:PutRecordBatch'
+              - 'dynamodb:DescribeStream'
+              - 'dynamodb:DescribeTable'
+              - 'dynamodb:GetRecords'
+              - 'dynamodb:GetShardIterator'
+              - 'dynamodb:ListStreams'
+              - 'dynamodb:ListTables'
+              - 'dynamodb:UpdateTable'
+              - 'logs:CreateLogGroup'
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+              - 'lambda:CreateFunction'
+              - 'lambda:CreateEventSourceMapping'
+              - 'lambda:ListEventSourceMappings'
+              - 'iam:passrole'
+              - 's3:Get*'
+              - 's3:List*'
+            Resource: '*'
+      Roles:
+        - !Ref DynamoDBBackupLambdaExecRole
+
+  DynamoDBBackupCloudWatchEventsRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: DynamoDB-Backup-CloudWatchEventsRole
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+
+  DynamoDBBackupCloudWatchEventsRolePolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyName: DynamoDB-Backup-CloudWatchEventsPolicy
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action:
+              - 'cloudtrail:GetTrailStatus'
+              - 'cloudtrail:DescribeTrails'
+              - 'cloudtrail:LookupEvents'
+              - 'cloudtrail:ListTags'
+              - 'cloudtrail:ListPublicKeys'
+              - 'cloudtrail:GetEventSelectors'
+              - 's3:ListAllMyBuckets'
+              - 's3:GetObject'
+              - 's3:GetBucketLocation'
+              - 'kms:ListAliases'
+              - 'logs:CreateLogGroup'
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+            Resource: '*'
+      Roles:
+        - !Ref DynamoDBBackupCloudWatchEventsRole


### PR DESCRIPTION
AWSlabs created a backup solution for dynamoDB.  This PR includes the config to setup our dev account to have dynamodb tables backed up to S3.  I've added the 3 qa tables in the whitelist insted of all tables.

Note that AWS will release an official DynamoDB backup solution at Re:Invent so this may be a moot point in the coming months.  I don't see this extending past the dev account, but the need to have that data backed up is immediate. 